### PR TITLE
Fix spelling error on TokenPage.tsx

### DIFF
--- a/src/pages/Token/TokenPage.tsx
+++ b/src/pages/Token/TokenPage.tsx
@@ -149,7 +149,7 @@ export default function TokenPage({
       {tokenData ? (
         !tokenData.exists ? (
           <LightGreyCard style={{ textAlign: 'center' }}>
-            No pool has been created with this token yet. Creat one
+            No pool has been created with this token yet. Create one
             <StyledExternalLink style={{ marginLeft: '4px' }} href={`https://app.uniswap.org/#/add/${address}`}>
               here.
             </StyledExternalLink>


### PR DESCRIPTION
This fixes a spelling error, "Creat" > "Create"