### PR TITLE
Fix: pool address logo does not exist

### DIFF
--- a/src/pages/Pool/PoolPage.tsx
+++ b/src/pages/Pool/PoolPage.tsx
@@ -73,7 +73,7 @@ export default function PoolPage({
   }, [])
 
   // theming
-  const backgroundColor = useColor(address)
+  const backgroundColor = useColor()
   const theme = useTheme()
 
   // token data


### PR DESCRIPTION
Changed the parameter of the useColor function as the LP logo does not exist and cannot be loaded.