### PR TITLE
Update useOnClickOutside.tsx

### DIFF
--- a/src/hooks/useOnClickOutside.tsx
+++ b/src/hooks/useOnClickOutside.tsx
@@ -17,10 +17,10 @@ export function useOnClickOutside<T extends HTMLElement>(
       if (handlerRef.current) handlerRef.current()
     }
 
-    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('click', handleClickOutside)
 
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('click', handleClickOutside)
     }
   }, [node])
 }


### PR DESCRIPTION
Change event listener in `useOnClickOutside` from on 'mousedown' to on 'click' to prevent overlay components from closing before links register the click event.