### PR TITLE
Fix ticks prices decimals

### DIFF
--- a/src/components/DensityChart/CurrentPriceLabel.tsx
+++ b/src/components/DensityChart/CurrentPriceLabel.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import { AutoColumn } from 'components/Column'
 import { RowFixed } from 'components/Row'
 import { TYPE } from 'theme'
+import { formatAmount } from 'utils/numbers'
 
 const Wrapper = styled.div`
   border-radius: 8px;
@@ -52,12 +53,12 @@ export function CurrentPriceLabel({ data, chartProps, poolData }: CurrentPriceLa
                   }}
                 ></div>
               </RowFixed>
-              <TYPE.label>{`1 ${poolData.token0.symbol} = ${Number(price0).toLocaleString(undefined, {
-                minimumSignificantDigits: 1,
-              })} ${poolData.token1.symbol}`}</TYPE.label>
-              <TYPE.label>{`1 ${poolData.token1.symbol} = ${Number(price1).toLocaleString(undefined, {
-                minimumSignificantDigits: 1,
-              })} ${poolData.token0.symbol}`}</TYPE.label>
+              <TYPE.label>{`1 ${poolData.token0.symbol} = ${formatAmount(price0, 4)} ${
+                poolData.token1.symbol
+              }`}</TYPE.label>
+              <TYPE.label>{`1 ${poolData.token1.symbol} = ${formatAmount(price1, 4)} ${
+                poolData.token0.symbol
+              }`}</TYPE.label>
             </AutoColumn>
           </Wrapper>
         </foreignObject>

--- a/src/components/DensityChart/CustomToolTip.tsx
+++ b/src/components/DensityChart/CustomToolTip.tsx
@@ -36,23 +36,13 @@ export function CustomToolTip({ chartProps, poolData, currentPrice }: CustomTool
         <RowBetween>
           <TYPE.label>{poolData?.token0?.symbol} Price: </TYPE.label>
           <TYPE.label>
-            {price0
-              ? Number(price0).toLocaleString(undefined, {
-                  minimumSignificantDigits: 1,
-                })
-              : ''}{' '}
-            {poolData?.token1?.symbol}
+            {price0 ? formatAmount(price0, 4) : ''} {poolData?.token1?.symbol}
           </TYPE.label>
         </RowBetween>
         <RowBetween>
           <TYPE.label>{poolData?.token1?.symbol} Price: </TYPE.label>
           <TYPE.label>
-            {price1
-              ? Number(price1).toLocaleString(undefined, {
-                  minimumSignificantDigits: 1,
-                })
-              : ''}{' '}
-            {poolData?.token0?.symbol}
+            {price1 ? formatAmount(price1, 4) : ''} {poolData?.token0?.symbol}
           </TYPE.label>
         </RowBetween>
         {currentPrice && price0 && currentPrice > price1 ? (

--- a/src/data/pools/tickData.ts
+++ b/src/data/pools/tickData.ts
@@ -5,7 +5,6 @@ import { TickMath, tickToPrice } from '@uniswap/v3-sdk'
 import { Token } from '@uniswap/sdk-core'
 import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
 
-const PRICE_FIXED_DIGITS = 4
 const DEFAULT_SURROUNDING_TICKS = 300
 const FEE_TIER_TO_TICK_SPACING = (feeTier: string): number => {
   switch (feeTier) {
@@ -231,8 +230,8 @@ export const fetchTicksSurroundingPrice = async (
     liquidityActive: JSBI.BigInt(liquidity),
     tickIdx: activeTickIdx,
     liquidityNet: JSBI.BigInt(0),
-    price0: tickToPrice(token0, token1, activeTickIdxForPrice).toFixed(PRICE_FIXED_DIGITS),
-    price1: tickToPrice(token1, token0, activeTickIdxForPrice).toFixed(PRICE_FIXED_DIGITS),
+    price0: tickToPrice(token0, token1, activeTickIdxForPrice).toFixed(token1.decimals),
+    price1: tickToPrice(token1, token0, activeTickIdxForPrice).toFixed(token0.decimals),
     liquidityGross: JSBI.BigInt(0),
   }
 
@@ -278,8 +277,8 @@ export const fetchTicksSurroundingPrice = async (
         liquidityActive: previousTickProcessed.liquidityActive,
         tickIdx: currentTickIdx,
         liquidityNet: JSBI.BigInt(0),
-        price0: tickToPrice(token0, token1, currentTickIdx).toFixed(PRICE_FIXED_DIGITS),
-        price1: tickToPrice(token1, token0, currentTickIdx).toFixed(PRICE_FIXED_DIGITS),
+        price0: tickToPrice(token0, token1, currentTickIdx).toFixed(token1.decimals),
+        price1: tickToPrice(token1, token0, currentTickIdx).toFixed(token0.decimals),
         liquidityGross: JSBI.BigInt(0),
       }
 


### PR DESCRIPTION
This PR fixes the number of decimals used to calculate the ticks' prices.

It was harcoded to use only 4 decimals, now it uses the token's decimals.

The tick's `price1` is used to calculate the TVL locked `amount0`. The loss of precision is causing the `amount0` to be incorrectly calculated.

https://github.com/Uniswap/uniswap-v3-info/blob/93eaaf001dbcc4981c3605f2ac8ad3593e310f8c/src/components/DensityChart/index.tsx#L162

I also replaced the formatting of prices using `toLocaleString` with `formatAmount(priceX, 4)`