### PR TITLE
Fix: Broken explorer links on Pool page

### DIFF
--- a/src/pages/Pool/PoolPage.tsx
+++ b/src/pages/Pool/PoolPage.tsx
@@ -31,7 +31,6 @@ import { GenericImageWrapper } from 'components/Logo'
 import { Navigate, useParams } from 'react-router-dom'
 import { Trace } from '@uniswap/analytics'
 import { InterfacePageName } from '@uniswap/analytics-events'
-import { ChainId } from '@uniswap/sdk-core'
 
 const ContentLayout = styled.div`
   display: grid;
@@ -166,7 +165,7 @@ function PoolPage({ address }: { address: string }) {
               </AutoRow>
               <RowFixed gap="10px" align="center">
                 <SavedIcon fill={savedPools.includes(address)} onClick={() => addSavedPool(address)} />
-                <StyledExternalLink href={getExplorerLink(ChainId.MAINNET, address, ExplorerDataType.ADDRESS)}>
+                <StyledExternalLink href={getExplorerLink(activeNetwork.chainId, address, ExplorerDataType.ADDRESS)}>
                   <ExternalLink stroke={theme?.text2} size={'17px'} style={{ marginLeft: '12px' }} />
                 </StyledExternalLink>
               </RowFixed>


### PR DESCRIPTION
## Issue
Explorer links on PoolPage are always linking to etherscan.io, regardless of the chosen chain

![broken-explorer-link](https://github.com/Uniswap/v3-info/assets/97852365/da50217a-55fe-4859-be09-64ce21235245)

Link out before fix:
https://github.com/Uniswap/v3-info/assets/97852365/e032e098-4c76-450d-9ac5-15f8aeead3bf

## Solution
Use the active chain's network id when building explorer link

Link out after fix:
https://github.com/Uniswap/v3-info/assets/97852365/5a1dd2c6-620d-4fd5-bee8-8e6634dffde5


